### PR TITLE
chore: add Dependabot config and fix .gitignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "larkly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 dist/
 build/
 .env
+.ruff_cache/


### PR DESCRIPTION
Adds .github/dependabot.yml covering pip and github-actions ecosystems, matching the pattern used by sibling repos (hermes-irc, mindmapconverter). Also adds .ruff_cache/ to .gitignore to prevent accidentally committing ruff cache directories.